### PR TITLE
Fix up instructions to run the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ You pass options to cmake as follows: ```cmake -DOPTION=VALUE```
 	cd libpaxos/build
 	./sample/acceptor 0 ../paxos.conf > /dev/null &
 	./sample/acceptor 1 ../paxos.conf > /dev/null &
-	./sample/proposer 0 ../paxos.conf > /dev/null &
+	./sample/proposer 2 ../paxos.conf > /dev/null &
 	./sample/learner ../paxos.conf > learner.txt &
-	./sample/client 127.0.0.1:5550 1
+	./sample/client
 
 ## Configuration
 


### PR DESCRIPTION
- Proposer and acceptor are using same port
- Sample client does not accept arguments

**When I try to run the example:**
```
build git:(master) ./sample/acceptor 0 ../paxos.conf > /dev/null &
./sample/acceptor 1 ../paxos.conf > /dev/null &
./sample/proposer 2 ../paxos.conf > /dev/null &
./sample/learner ../paxos.conf > learner.txt &
./sample/client 127.0.0.1:5550 1
[3] 21769
[5] 21770
[6] 21771
[14] 21772
[5]    21770 exit 1     ./sample/acceptor 1 ../paxos.conf > /dev/null
[3]    21769 exit 1     ./sample/acceptor 0 ../paxos.conf > /dev/null
Usage: ./sample/client [path/to/paxos.conf] [-h] [-o] [-v] [-p]
  -h, --help                    Output this message and exit
  -o, --outstanding #           Number of outstanding client values
  -v, --value-size #            Size of client value (in bytes)
  -p, --proposer-id #           d of the proposer to connect to
```

**By applying these changes:**
```
build git:(master) ./sample/acceptor 0 ../paxos.conf > /dev/null &
./sample/acceptor 1 ../paxos.conf > /dev/null &
./sample/proposer 2 ../paxos.conf > /dev/null &
./sample/learner ../paxos.conf > learner.txt &
./sample/client
[3] 21794
[5] 21795
[15] 21796
[16] 21797
[3]    21794 exit 1     ./sample/acceptor 0 ../paxos.conf > /dev/null
[5]    21795 exit 1     ./sample/acceptor 1 ../paxos.conf > /dev/null
[15]  - 21796 exit 1     ./sample/proposer 2 ../paxos.conf > /dev/null
16 Feb 13:07:12. Connect to 127.0.0.1:8800
16 Feb 13:07:12. Connect to 127.0.0.1:8801
16 Feb 13:07:12. Connect to 127.0.0.1:8802
16 Feb 13:07:12. Connect to 127.0.0.1:8803
16 Feb 13:07:12. Connect to 127.0.0.1:8804
16 Feb 13:07:12. Connect to 127.0.0.1:8805
16 Feb 13:07:12. Connect to 127.0.0.1:8806
16 Feb 13:07:12. Connect to 127.0.0.1:8807
16 Feb 13:07:12. Connect to 127.0.0.1:8808
Connected to proposer
16 Feb 13:07:12. Connected to 127.0.0.1:8800
16 Feb 13:07:12. Connected to 127.0.0.1:8801
16 Feb 13:07:12. Connected to 127.0.0.1:8802
16 Feb 13:07:12. Connection refused (127.0.0.1:8803)
16 Feb 13:07:12. Connection refused (127.0.0.1:8804)
16 Feb 13:07:12. Connection refused (127.0.0.1:8805)
16 Feb 13:07:12. Connection refused (127.0.0.1:8806)
16 Feb 13:07:12. Connection refused (127.0.0.1:8807)
16 Feb 13:07:12. Connection refused (127.0.0.1:8808)
0 value/sec, 0.00 Mbps, latency min 0 us max 0 us avg 0 us
0 value/sec, 0.00 Mbps, latency min 0 us max 0 us avg 0 us

and so on
```